### PR TITLE
reduce dependency. fix workspace profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,13 @@ members = [
     "./flashfunk-core",
 ]
 
+[profile.release]
+lto = "fat"
+opt-level = 3
+codegen-units = 1
+debug-assertions = false
+overflow-checks = false
+panic = "abort"
 
+[profile.dev]
+rpath = true

--- a/flashfunk-core/Cargo.toml
+++ b/flashfunk-core/Cargo.toml
@@ -11,17 +11,8 @@ core_affinity = "0.5.10"
 encoding = "0.2.33"
 libc = "0.2.0"
 flashfunk-level = { path = "../flashfunk-level"}
-async-trait = ""
+async-trait = "0.1.50"
 chrono-tz = { version = "0.5", features = ["serde"] }
 clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs/", branch = "async-await" }
-futures = "0.3.8"
-tokio = { version = "1.5" }
-once_cell = ""
-
-[profile.release]
-lto = "fat"
-opt-level = 3
-codegen-units = 1
-debug-assertions = false
-overflow-checks = false
-panic = "abort"
+tokio = { version = "1.5", features = ["sync"] }
+once_cell = "1.8.0"

--- a/flashfunk-level/Cargo.toml
+++ b/flashfunk-level/Cargo.toml
@@ -30,10 +30,6 @@ default = ["ctp"]
 ctp = []
 ctp_mini = []
 
-
-[profile.dev]
-rpath = true
-
 [build-dependencies]
 bindgen = "0.55.1"
 cc = "1.0"

--- a/flashfunk-level/src/lib.rs
+++ b/flashfunk-level/src/lib.rs
@@ -44,11 +44,11 @@ fn os_path(target: &str) -> PathBuf {
     let path = PathBuf::from(format!("{}", var("HOME").unwrap()));
     let path = path.join(".HFQ");
     if !path.exists() {
-        fs::create_dir(path.clone());
+        fs::create_dir(path.clone()).unwrap();
     }
     let p = path.join(target);
     if !p.exists() {
-        fs::create_dir(p.clone());
+        fs::create_dir(p.clone()).unwrap();
     }
     p
 }


### PR DESCRIPTION
Remove `futures` crate from dependency.

Move profiles in workspace members to workspace itself. 
As profiles for the non root package will be ignored and they must be specified at the workspace root