### PR TITLE
use drain on position. make orderid non option

### DIFF
--- a/flashfunk-core/src/account.rs
+++ b/flashfunk-core/src/account.rs
@@ -200,7 +200,7 @@ impl Account {
             Status::CANCELLED => {
                 // Remove Margin frozen
                 self.margin_frozen_container
-                    .remove(&data.orderid.clone().unwrap());
+                    .remove(&data.orderid.clone());
             }
             _ => {}
         }
@@ -210,7 +210,7 @@ impl Account {
                 // Add Margin frozen
                 let ratio = self.get_margin_ratio(&symbol);
                 self.margin_frozen_container
-                    .insert(data.orderid.unwrap(), data.volume * data.price * ratio);
+                    .insert(data.orderid, data.volume * data.price * ratio);
             }
             _ => {}
         }

--- a/flashfunk-core/src/mock.rs
+++ b/flashfunk-core/src/mock.rs
@@ -140,7 +140,7 @@ impl MockTdApi {
             symbol: order_req.symbol.clone(),
             exchange: order_req.exchange,
             datetime: self.current_tick.datetime,
-            orderid: Some(format!("{}_{}", idx, req_id)),
+            orderid: format!("{}_{}", idx, req_id),
             order_type: order_req.order_type,
             direction: Some(order_req.direction),
             offset: order_req.offset,
@@ -358,9 +358,9 @@ impl Interface for MockTdApi {
             // 冻结账户保证金
             self.acc.update_order(order_data.clone());
             self.active_order_map
-                .insert(order_data.orderid.clone().unwrap(), order_data.clone());
+                .insert(order_data.orderid.clone(), order_data.clone());
             self.queue_num_map
-                .insert(order_data.orderid.clone().unwrap(), QUEUE_INIT);
+                .insert(order_data.orderid.clone(), QUEUE_INIT);
             self.sender.try_send_to(order_data, idx).unwrap_or(());
         } else {
             // 拒单

--- a/flashfunk-level/src/context.rs
+++ b/flashfunk-level/src/context.rs
@@ -28,7 +28,7 @@ pub struct ContextInner {
 
 impl ContextInner {
     pub fn add_order(&mut self, order: OrderData) {
-        self.order_map.insert(order.orderid.clone().unwrap(), order);
+        self.order_map.insert(order.orderid.clone(), order);
     }
 
     pub fn get_active_orders(&self) -> impl Iterator<Item = &OrderData> {

--- a/flashfunk-level/src/data_type.rs
+++ b/flashfunk-level/src/data_type.rs
@@ -82,7 +82,7 @@ pub struct OrderData {
     pub symbol: String,
     pub exchange: Exchange,
     pub datetime: NaiveDateTime,
-    pub orderid: Option<String>,
+    pub orderid: String,
     pub order_type: OrderType,
     pub direction: Option<Direction>,
     pub offset: Offset,


### PR DESCRIPTION
use drain on position data. This would return ownership and clear the map at the same time.

Remove Cow usage where there is no borrowed case to reduce branch matching.

Make order id non option to reduce branch matching.