### PR TITLE
stop leaking tick data

### DIFF
--- a/flashfunk-core/src/mock.rs
+++ b/flashfunk-core/src/mock.rs
@@ -1,6 +1,8 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
 
+use std::borrow::Cow;
+use std::io::prelude::*;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::thread::JoinHandle;
@@ -16,8 +18,6 @@ use flashfunk_level::interface::Interface;
 use flashfunk_level::types::message::{MdApiMessage, TdApiMessage};
 use flashfunk_level::util::channel::GroupSender;
 use flashfunk_level::util::hash::HashMap;
-use std::borrow::Cow;
-use std::io::prelude::*;
 
 const QUEUE_INIT: i32 = 888_888;
 
@@ -106,7 +106,7 @@ impl Interface for MockMdApi {
 
                             // 在这里修改tick data数据;
                             let tick = TickData::from(&ticks.remove(0));
-                            let msg: &'static TickData = Box::leak(Box::new(tick));
+                            let msg = Arc::new(tick);
                             //let msg: &'static TickData = Box::leak(Box::new(TickData::default()));
 
                             sender.send_all(msg);

--- a/flashfunk-core/src/worker.rs
+++ b/flashfunk-core/src/worker.rs
@@ -105,7 +105,7 @@ impl StrategyWorker {
             // 接收md_api的消息并处理。
             if let Ok(msg) = self.c_md.recv() {
                 match msg {
-                    MdApiMessage::TickData(ref data) => self.st.on_tick(data, &mut ctx),
+                    MdApiMessage::TickData(data) => self.st.on_tick(&*data, &mut ctx),
                     MdApiMessage::SubscribeRequest(_req) => unimplemented!(),
                     MdApiMessage::Log(ref data) => {
                         if data.level.eq(&LogLevel::INFO) {

--- a/flashfunk-level/src/ctp/mdapi.rs
+++ b/flashfunk-level/src/ctp/mdapi.rs
@@ -159,7 +159,7 @@ impl CtpMdCApi for Level {
                     }
                 };
 
-                let msg: &'static TickData = Box::leak(Box::new(msg));
+                let msg = Arc::new(msg);
 
                 // 如果需要错误处理请在这里取回消息
 

--- a/flashfunk-level/src/data_type.rs
+++ b/flashfunk-level/src/data_type.rs
@@ -35,7 +35,7 @@ pub struct TickData {
 impl Default for TickData {
     fn default() -> TickData {
         TickData {
-            symbol: String::from(""),
+            symbol: String::new(),
             exchange: Exchange::INIT,
             datetime: chrono::Utc::now().naive_utc(),
             volume: 0,

--- a/flashfunk-level/src/types/message.rs
+++ b/flashfunk-level/src/types/message.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::data_type::{
     AccountData, CancelRequest, ContractData, ContractStatus, ContractVec, ExtraOrder, ExtraTrade,
     Log, OrderData, OrderRequest, PositionData, QueryRequest, SubscribeRequest, TickData,
@@ -5,7 +7,7 @@ use crate::data_type::{
 };
 
 pub enum MdApiMessage {
-    TickData(&'static TickData),
+    TickData(Arc<TickData>),
     SubscribeRequest(SubscribeRequest),
     Log(Log),
 }
@@ -16,8 +18,8 @@ impl From<SubscribeRequest> for MdApiMessage {
     }
 }
 
-impl From<&'static TickData> for MdApiMessage {
-    fn from(data: &'static TickData) -> Self {
+impl From<Arc<TickData>> for MdApiMessage {
+    fn from(data: Arc<TickData>) -> Self {
         Self::TickData(data)
     }
 }


### PR DESCRIPTION
Stop leaking TickData.

This would have a couple of overhead with atomic operation but it's manageable than constant leaking heap.