### PR TITLE
remove all allocation for generate tick data.

### DIFF
--- a/flashfunk-level/benchmark/tick_generation.rs
+++ b/flashfunk-level/benchmark/tick_generation.rs
@@ -138,7 +138,7 @@ fn convert_to(field: *mut CThostFtdcDepthMarketDataField, symbol: &'static str) 
     unsafe {
         let depth = *field;
         let v = depth.InstrumentID.as_ptr();
-        let symbol = std::str::from_utf8_unchecked(CStr::from_ptr(v).to_bytes());
+        let _s = std::str::from_utf8_unchecked(CStr::from_ptr(v).to_bytes());
         let (date, time) = parse_datetime_from_str(
             depth.ActionDay.as_ptr(),
             depth.UpdateTime.as_ptr(),

--- a/flashfunk-level/benchmark/tick_generation.rs
+++ b/flashfunk-level/benchmark/tick_generation.rs
@@ -128,17 +128,17 @@ impl CThostFtdcDepthMarketDataField {
 fn criterion_benchmark(c: &mut Criterion) {
     let x = CThostFtdcDepthMarketDataField::new();
     let v = Box::into_raw(Box::new(x)) as *mut CThostFtdcDepthMarketDataField;
-    c.bench_function("c tick data", |b| b.iter(|| convert_to(v.clone())));
+    let symbol: &'static str = Box::leak(String::from("rb2021").into_boxed_str());
+    c.bench_function("c tick data", |b| b.iter(|| convert_to(v.clone(), symbol)));
 }
 
 #[doc(hidden)]
 // 主要耗费延时函数 CThostFtdcDepthMarketDataField
-fn convert_to(field: *mut CThostFtdcDepthMarketDataField) -> TickData {
+fn convert_to(field: *mut CThostFtdcDepthMarketDataField, symbol: &'static str) -> TickData {
     unsafe {
         let depth = *field;
         let v = depth.InstrumentID.as_ptr();
-        let symbol = CStr::from_ptr(v).to_str().unwrap();
-        let symbol = symbol.to_owned();
+        let symbol = std::str::from_utf8_unchecked(CStr::from_ptr(v).to_bytes());
         let (date, time) = parse_datetime_from_str(
             depth.ActionDay.as_ptr(),
             depth.UpdateTime.as_ptr(),
@@ -146,7 +146,7 @@ fn convert_to(field: *mut CThostFtdcDepthMarketDataField) -> TickData {
         );
 
         TickData {
-            symbol,
+            symbol: Cow::Borrowed(symbol),
             datetime: NaiveDateTime::new(date, time),
             volume: depth.Volume,
             open_interest: depth.OpenInterest,

--- a/flashfunk-level/src/ctp/mdapi.rs
+++ b/flashfunk-level/src/ctp/mdapi.rs
@@ -100,13 +100,12 @@ impl CtpMdCApi for Level {
 
             let v = depth.InstrumentID.as_ptr();
 
-            let symbol = CStr::from_ptr(v).to_str().unwrap();
+            let symbol = std::str::from_utf8_unchecked(CStr::from_ptr(v).to_bytes());
 
             let index = self.symbols.iter().enumerate().find(|(i, s)| **s == symbol);
 
-            if let Some((i, _)) = index {
+            if let Some((i, symbol)) = index {
                 let msg = {
-                    let symbol = symbol.to_owned();
                     let (date, time) = parse_datetime_from_str(
                         depth.ActionDay.as_ptr(),
                         depth.UpdateTime.as_ptr(),
@@ -114,7 +113,7 @@ impl CtpMdCApi for Level {
                     );
 
                     TickData {
-                        symbol,
+                        symbol: Cow::Borrowed(*symbol),
                         datetime: NaiveDateTime::new(date, time),
                         volume: depth.Volume,
                         open_interest: depth.OpenInterest,

--- a/flashfunk-level/src/data_type.rs
+++ b/flashfunk-level/src/data_type.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 /// Tick Data
 #[derive(Clone)]
 pub struct TickData {
-    pub symbol: String,
+    pub symbol: Cow<'static, str>,
     pub exchange: Exchange,
     pub datetime: NaiveDateTime,
     pub volume: i32,
@@ -34,7 +34,7 @@ pub struct TickData {
 impl Default for TickData {
     fn default() -> TickData {
         TickData {
-            symbol: String::new(),
+            symbol: Cow::Owned(String::new()),
             exchange: Exchange::INIT,
             datetime: chrono::Utc::now().naive_utc(),
             volume: 0,
@@ -142,7 +142,7 @@ impl DerefMut for ExtraTrade {
 impl From<&Tick> for TickData {
     fn from(tick: &Tick) -> Self {
         TickData {
-            symbol: tick.local_symbol.clone(),
+            symbol: Cow::Owned(tick.local_symbol.clone()),
             exchange: Exchange::INIT,
             datetime: tick.datetime,
             volume: tick.volume,


### PR DESCRIPTION
MdApi holds 'static lifetime symbol already. Pass it to TickData would be cheaper than allocate the Cstr to a String.